### PR TITLE
Fix argument exception typo

### DIFF
--- a/CachingWrapper.cs
+++ b/CachingWrapper.cs
@@ -49,7 +49,7 @@ namespace Utilities
         {
             if (originalSourceRetriever == null)
             {
-                throw new ArgumentException("originalSourcerRetriever cannot be null");
+                throw new ArgumentException("originalSourceRetriever cannot be null");
             }
 
             _originalSourceRetriever += originalSourceRetriever;


### PR DESCRIPTION
## Summary
- fix typo in argument exception string

## Testing
- `grep -R "SourcerRetriever" -n`

------
https://chatgpt.com/codex/tasks/task_e_684007eaf0948325bbc80cee44404845