### PR TITLE
Add cache clearing unit test

### DIFF
--- a/CachingWrapperTests.cs
+++ b/CachingWrapperTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -72,6 +73,29 @@ namespace Utilities.Tests
             Assert.AreEqual(MockedResult(1), cachedSource.Retrieve(1), "Wrong element was returned from cache!");
 
             Assert.AreEqual(7, _cacheMisses, "There should be 7 cache misses so far");
+        }
+
+        [Description("CachingWrapper tester")]
+        [TestMethod]
+        public void TestClearCache()
+        {
+            _cacheMisses = 0;
+
+            var cachedSource = new CachingWrapper<int, string>(DatabaseCallMock, 3);
+
+            cachedSource.Retrieve(0);
+            cachedSource.Retrieve(1);
+            cachedSource.Retrieve(2);
+
+            var cleared = cachedSource.ClearCache(Timeout.Infinite);
+
+            Assert.IsTrue(cleared, "ClearCache should return true when the cache is cleared.");
+
+            int missesBefore = _cacheMisses;
+
+            cachedSource.Retrieve(0);
+
+            Assert.AreEqual(missesBefore + 1, _cacheMisses, "Cache miss count should increment after clearing the cache.");
         }
 
         [Description("CachingWrapper tester")]


### PR DESCRIPTION
## Summary
- add `TestClearCache` method to verify `ClearCache` empties the cache
- include `System.Threading` namespace for `Timeout` constant

## Testing
- `dotnet test` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840080b5a5883259e935cfa3968e82a