### PR TITLE
Fix default constructor syntax

### DIFF
--- a/CachingWrapper.cs
+++ b/CachingWrapper.cs
@@ -36,7 +36,8 @@ namespace Utilities
         /// Initializes a new instance of the <see cref="CachingWrapper{TKey,TValue}"/> class.
         /// </summary>
         /// <param name="originalSourceRetriever">The method that will return an element if it is not in the cache.</param>
-        public CachingWrapper(RetrieveFromOriginalSource originalSourceRetriever : this(originalSourceRetriever, 0)
+        public CachingWrapper(RetrieveFromOriginalSource originalSourceRetriever)
+            : this(originalSourceRetriever, 0)
         {
         }
 


### PR DESCRIPTION
## Summary
- fix the `CachingWrapper` default constructor syntax to chain properly
- verify compilation using `dotnet build`

## Testing
- `dotnet build TestLib/TestLib.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68400800825883258bf8eda1d1f5bfb7