### PR TITLE
Fix typo in CachingWrapper documentation

### DIFF
--- a/CachingWrapper.cs
+++ b/CachingWrapper.cs
@@ -13,7 +13,7 @@ namespace Utilities
     public class CachingWrapper<TKey, TValue> where TKey : IComparable
     {
         /// <summary>
-        /// The delegate method that will be called when a request cannot be fullfilled from the cache
+        /// The delegate method that will be called when a request cannot be fulfilled from the cache
         /// </summary>
         /// <param name="key">The Key</param>
         /// <returns>The value</returns>


### PR DESCRIPTION
## Summary
- fix a spelling mistake in `CachingWrapper.cs`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400806f1b0832584af7d3e903f6252